### PR TITLE
Don't mount the target file system if 'canmount' is not set to 'on'

### DIFF
--- a/zfs-backup.sh
+++ b/zfs-backup.sh
@@ -244,6 +244,15 @@ do_backup() {
 	return 1
     fi
 
+    # Don't mount the target file system after receiving the stream associated
+    # with it if the 'canmount' property is not set to 'on'
+    if [ "$REMHOST" = "localhost" ]; then
+      canmount_target="$($ZFS get -H -o value canmount $TARGET)"
+    else
+      canmount_target="$(ssh -n $REMUSER@$REMHOST $REMZFS get -H -o value canmount $TARGET)"
+    fi
+    if [ "$canmount_target" != "on" ]; then RECV_OPT="$RECV_OPT -u"; fi
+
     if [ $DEBUG ]; then
 	echo "would run: $PFEXEC $ZFS send -R -I $snap1 $DATASET@$snap2 |"
 	echo "  $REMZFS_CMD recv $VERBOSE $RECV_OPT -F $REMPOOL"


### PR DESCRIPTION
I have a pool (`tank`) with the following filesets, which I'm trying to replicate to another pool (`backup`) on a remote host (`espoo`):

```
$ zfs get -t filesystem -r canmount tank
tank                  canmount  on        default
tank/media            canmount  on        default
tank/scratch          canmount  on        default
tank/timemachine      canmount  on        default
tank/x220             canmount  off       local
tank/x220/zroot       canmount  noauto    local
tank/x220/zroot/home  canmount  noauto    local
tank/x220/zroot/root  canmount  noauto    local
```

By default, ZFS will try to mount the target file system associated with the received stream. If the `canmount` property is set to any other value than `on` (e.g. `noauto`), mounting will fail and the service will enter maintenance state:

```
tank/x220/zroot:
newest local snapshot: zfs-auto-snap_daily-2015-04-15-2100
newest remote snapshot: zfs-auto-snap_daily-2015-04-14-0854
[...]
receiving incremental stream of tank/x220/zroot/root@zfs-auto-snap_daily-2015-04-15-2100 into backup/x220/zroot/root@zfs-auto-snap_daily-2015-04-15-2100
cannot mount 'backup/x220/zroot': Insufficient privileges
received 179KB stream in 8 seconds (22.4KB/sec)
Error sending snapshot.
```

This pull request adds a check for the `canmount` property, and if it's set to a value other than `on`, the `-u` parameter is passed to `zfs recv`:

```
       -u

           File  system  that  is associated with the received stream is not          
           mounted.
```

Example dry-run output:

```
tank/media:
newest local snapshot: zfs-auto-snap_daily-2015-04-21-03h10
newest remote snapshot: zfs-auto-snap_daily-2015-04-20-03h10
would run:  /sbin/zfs send -R -I zfs-auto-snap_daily-2015-04-20-03h10 tank/media@zfs-auto-snap_daily-2015-04-21-03h10 |
  ssh zfsbak@espoo /sbin/zfs recv -v -d -F backup
[...]
tank/x220/zroot:
newest local snapshot: zfs-auto-snap_daily-2015-04-20-2100
newest remote snapshot: zfs-auto-snap_daily-2015-04-19-2146
would run:  /sbin/zfs send -R -I zfs-auto-snap_daily-2015-04-19-2146 tank/x220/zroot@zfs-auto-snap_daily-2015-04-20-2100 |
  ssh zfsbak@espoo /sbin/zfs recv -v -d -u -F backup
```
